### PR TITLE
Add docker-compose setup and make onboarding easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project-specific rules
 autoapi.sqlite
-node_modules/
+node_modules
+data_sources/
 raw/*
 
 # Byte-compiled / optimized / DLL files

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 autoapi.sqlite
 node_modules
 data_sources/
+.env
 raw/*
 
 # Byte-compiled / optimized / DLL files

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM tsutomu7/alpine-python-pandas
-ADD . /autoapi
-WORKDIR /autoapi
 
 # alpine base image is lacking some repositories, frequently causing
 # downtime when updating packages
@@ -11,6 +9,17 @@ RUN apk add gcc g++ make libffi-dev openssl-dev python3-dev build-base --update-
 RUN apk add nodejs git postgresql postgresql-dev
 RUN mkdir /ve
 RUN pyvenv --system-site-packages /ve/std
-RUN pip install -r /autoapi/requirements.txt
-RUN npm install
+
+COPY requirements.txt /
+
+RUN pip install -r /requirements.txt
+
+# http://bitjudo.com/blog/2014/03/13/building-efficient-dockerfiles-node-dot-js/
+COPY package.json /tmp/package.json
+RUN cd /tmp && npm install
+RUN mkdir -p /autoapi && cp -a /tmp/node_modules /autoapi/
+
+COPY . /autoapi
+
+WORKDIR /autoapi
 CMD /autoapi/run_in_docker.sh

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,7 @@ Summary
 
 AutoAPI is a very simple, very scalable API engine that converts flat data files into a web service.  To add, edit, and remove data from the API, you just add, overwrite, or delete flat files from an s3 bucket.
 
+
 Example Instance
 ----------------
 
@@ -22,23 +23,55 @@ Query Parameters:
 * ?[columnheader1]=[value1]&[columnheader3]=[value4]  (returns results that have both value1 and value2)
 
 
+Requirements
+------------
+
+In order to use autoapi, you'll need:
+
+* Python 3.5
+* npm
+
+Alternatively, if you use Docker for development and/or deployment, you don't
+need anything (except Docker, of course).
+
 
 Quickstart
 ----------
 
-::
+First, let's get dependencies sorted out::
 
-    pip install invoke
-    invoke requirements
-    export AWS_ACCESS_KEY_ID="..."
-    export AWS_SECRET_ACCESS_KEY="..."
-    export AUTOAPI_BUCKET="..."
+    pip3 install -r requirements.txt
+    npm install
+
+The easiest way to get started with autoapi is by serving CSV files from
+your local filesystem.
+
+Here's a quick way to generate some sample data::
+
+    mkdir data_sources
+    cat << EOF > data_sources/my_sample_data.csv
+    name,color
+    apple,red
+    grapefruit,pink
+    EOF
+
+Now you can add your sample data to a local SQLite database::
+
+    invoke apify "/data_sources/**.*"
+
+Finally, you can start the server with::
+
     invoke serve
 
-    curl http://localhost:5000
-    curl http://localhost:5000/sample
-    curl http://localhost:5000/sample/1
-    curl http://localhost:5000/sample?LastName=SMITH
+Now try visiting http://localhost:5000 in your browser, or poke at
+the following URLs from the command-line::
+
+    curl http://localhost:5000/my_sample_data
+    curl http://localhost:5000/my_sample_data/1
+    curl http://localhost:5000/my_sample_data?color=pink
+
+More details can be found in `instructions.md <https://github.com/18F/autoapi/blob/master/instructions.md>`_.
+
 
 Deployment via docker
 ---------------------
@@ -48,12 +81,10 @@ container with no further setup::
 
     docker run \
       -p 5000:5000 \
-      -e "AUTOAPI_NAME=$AUTOAPI_NAME" \
-      -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-      -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
-      -e "AUTOAPI_BUCKET=$AUTOAPI_BUCKET" \
       -v `pwd`/data_sources:/data_sources \
       --rm -it 18fgsa/autoapi
+
+Any environment variables can be set via the ``-e NAME=VALUE`` option.
 
 Note that this sets up your autoapi instance by directly
 pulling autoapi from its
@@ -61,20 +92,12 @@ pulling autoapi from its
 even require you to clone autoapi's git repository. However, as a
 result you won't be able to develop autoapi itself.
 
+
 Development via docker
 ----------------------
 
 If you'd like to use Docker for developing autoapi, just clone its
-repository and generate some sample data::
-
-    mkdir data_sources
-    cat << EOF > data_sources/my_sample_data.csv
-    name,color
-    apple,red
-    grapefruit,pink
-    EOF
-
-Then you'll want to build the docker image and start the server::
+repository, build the docker image and start the server::
 
     docker-compose build
     docker-compose up
@@ -91,10 +114,11 @@ or ``package.json``, just re-run ``docker-compose build``.
 For more information on using Docker for development, see the
 `18F Docker Guide <https://pages.18f.gov/dev-environment-standardization/virtualization/docker/>`_.
 
+
 Database Configuration
 ----------------------
 
-By default, autoapi uses a local SQLite database. To specify a different database URI, set the `DATABASE_URL` environment variable. For use with Cloud Foundry, simply create and bind an RDS service; this will automatically configure the environment.
+By default, autoapi uses a local SQLite database. To specify a different database URI, set the ``DATABASE_URL`` environment variable. For use with Cloud Foundry, simply create and bind an RDS service; this will automatically configure the environment.
 
 ::
 
@@ -103,17 +127,18 @@ By default, autoapi uses a local SQLite database. To specify a different databas
 
 For details on RDS services available through 18F Cloud Foundry, see https://docs.cloud.gov/apps/databases/.
 
-Example Implementation
-----------------------
-
-* https://autoapi.18f.gov/
-* if you want to see json, you can `curl https://autoapi.18f.gov`
-* https://autoapi.18f.gov/admin
 
 AWS Integration
 ---------------
 
-**autoapi** synchronizes with the S3 bucket specified in the `AUTOAPI_BUCKET` environment variable. On starting the API server, **autoapi** creates a subscription to the target bucket using Amazon SNS. When files are added to or deleted from the bucket, the corresponding endpoints will automatically be updated on the API.
+To use AWS instead of local CSV files, you'll want to define the following
+environment variables:
+
+* ``AUTOAPI_BUCKET`` - The bucket containing your CSV files.
+* ``AWS_ACCESS_KEY_ID`` - Your AWS access key.
+* ``AWS_SECRET_ACCESS_KEY`` - Your AWS secret access key.
+
+**autoapi** synchronizes with the S3 bucket specified in the ``AUTOAPI_BUCKET`` environment variable. On starting the API server, **autoapi** creates a subscription to the target bucket using Amazon SNS. When files are added to or deleted from the bucket, the corresponding endpoints will automatically be updated on the API.
 
 
 Public domain

--- a/README.rst
+++ b/README.rst
@@ -40,8 +40,8 @@ Quickstart
     curl http://localhost:5000/sample/1
     curl http://localhost:5000/sample?LastName=SMITH
 
-Via docker
-----------
+Deployment via docker
+---------------------
 
 If you have `Docker <http://docker.io>`_ installed, you can run from a Docker
 container with no further setup::
@@ -54,6 +54,42 @@ container with no further setup::
       -e "AUTOAPI_BUCKET=$AUTOAPI_BUCKET" \
       -v `pwd`/data_sources:/data_sources \
       --rm -it 18fgsa/autoapi
+
+Note that this sets up your autoapi instance by directly
+pulling autoapi from its
+`Docker Hub image <https://hub.docker.com/r/18fgsa/autoapi/>`_; it doesn't
+even require you to clone autoapi's git repository. However, as a
+result you won't be able to develop autoapi itself.
+
+Development via docker
+----------------------
+
+If you'd like to use Docker for developing autoapi, just clone its
+repository and generate some sample data::
+
+    mkdir data_sources
+    cat << EOF > data_sources/my_sample_data.csv
+    name,color
+    apple,red
+    grapefruit,pink
+    EOF
+
+Then you'll want to build the docker image and start the server::
+
+    docker-compose build
+    docker-compose up
+
+Now you can visit your server at http://localhost:5000.
+
+If you want to set any environment variables, you can do so by creating
+a ``.env`` file in the root directory of the repository, where each line
+consists of a ``NAME=VALUE`` pair.
+
+If any dependencies change, such as those listed in ``requirements.txt``
+or ``package.json``, just re-run ``docker-compose build``.
+
+For more information on using Docker for development, see the
+`18F Docker Guide <https://pages.18f.gov/dev-environment-standardization/virtualization/docker/>`_.
 
 Database Configuration
 ----------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+app:
+  build: .
+  volumes:
+    - .:/autoapi
+    - ./data_sources:/data_sources
+  entrypoint: python3 entrypoint.py
+  command: ./run_in_docker.sh
+  ports:
+    - "5000:5000"

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -2,11 +2,13 @@ import os
 import sys
 import pwd
 import subprocess
+from dotenv import load_dotenv
 
 
 MY_DIR = os.path.abspath(os.path.dirname(__file__))
 HOST_UID = os.stat(MY_DIR).st_uid
 HOST_USER = 'autoapi_user'
+DOTENV_PATH = os.path.join(os.path.dirname(__file__), '.env')
 
 
 def entrypoint(argv):
@@ -67,4 +69,6 @@ def does_uid_exist(uid):
 
 
 if __name__ == "__main__":
+    if os.path.exists(DOTENV_PATH):
+        load_dotenv(DOTENV_PATH)
     entrypoint(sys.argv)

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import pwd
+import subprocess
+
+
+MY_DIR = os.path.abspath(os.path.dirname(__file__))
+HOST_UID = os.stat(MY_DIR).st_uid
+HOST_USER = 'autoapi_user'
+
+
+def entrypoint(argv):
+    '''
+    This is a Docker entrypoint that configures the container to run
+    as the same uid of the user on the host container, rather than
+    the Docker default of root. Aside from following security best
+    practices, this makes it so that any files created by the Docker
+    container are also owned by the same user on the host system.
+    '''
+
+    if HOST_UID != os.geteuid():
+        if not does_uid_exist(HOST_UID):
+            username = HOST_USER
+            while does_username_exist(username):
+                username += '0'
+            home_dir = '/home/%s' % username
+            subprocess.check_call([
+                'adduser',
+                '-h', home_dir,
+                '-u', str(HOST_UID),
+                '-S', username,
+            ])
+        os.environ['HOME'] = '/home/%s' % pwd.getpwuid(HOST_UID).pw_name
+        os.setuid(HOST_UID)
+
+    if not os.path.exists('/autoapi/node_modules'):
+        subprocess.check_call(
+            "ln -s /tmp/node_modules /autoapi/node_modules",
+            shell=True
+        )
+
+    os.execvp(argv[1], argv[1:])
+
+
+def does_username_exist(username):
+    '''
+    Returns True if the given OS username exists, False otherwise.
+    '''
+
+    try:
+        pwd.getpwnam(username)
+        return True
+    except KeyError:
+        return False
+
+
+def does_uid_exist(uid):
+    '''
+    Returns True if the given OS user id exists, False otherwise.
+    '''
+
+    try:
+        pwd.getpwuid(uid)
+        return True
+    except KeyError:
+        return False
+
+
+if __name__ == "__main__":
+    entrypoint(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.1.1
 csvkit>=0.9.1
-invoke>=0.10.1
+invoke==0.10.1
 pandas
 # intentionally leaving pandas version blank, b/c `pip install` generally
 # fails on Linux - must use the package manager version

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,5 @@ cfenv==0.5.2
 
 git+https://github.com/18f/sandman2@table-delete
 git+https://github.com/marshmallow-code/smore@dev
+
+python-dotenv==0.5.1


### PR DESCRIPTION
This makes it easier to develop autoapi with docker-compose, and also fixes a few things:
- Fixes #58.
- Uses [`COPY` instead of `ADD`](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy).
- Optimizes use of the [build cache](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#build-cache) when generating layers for the image. Previously, changing any files in the source directory would rebuild the entire image from scratch, which takes quite some time and means bigger downloads from docker hub; now layers are reused so that a minor change to the source code results in a very quick image rebuild, and a top-level fs layer change so very little needs to be downloaded from docker hub.
- Adds a `docker-compose.yml` to make it easier to _develop_ (not just deploy) the site via `docker-compose up`.
- Re-organizes the documentation a bit to make it easier to understand and get started with things.

To do:
- [x] Document the new functionality, making sure to distinguish between _deploying_ with docker vs. _developing_ with docker.
- [x] Document Docker's existing use of the `data_sources` directory. This took me a little while to figure out.
- [x] Propagate environment variables into the docker container, either through `docker-compose.yml` or something like [python-dotenv](https://pypi.python.org/pypi/python-dotenv).
