### PR TITLE
Pin requirements.txt dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.7.0
 gunicorn==19.3.0
 cryptography>=1.0
 Flask==0.10.1
-Flask-SQLAlchemy==1.0
+Flask-SQLAlchemy==2.1
 Flask-Cors==2.1.0
 Flask-BasicAuth==0.2.0
 marshmallow==2.0.0.b4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,19 @@
-boto3>=1.1.1
-csvkit>=0.9.1
+boto3==1.1.1
+csvkit==0.9.1
 invoke==0.10.1
 pandas
 # intentionally leaving pandas version blank, b/c `pip install` generally
 # fails on Linux - must use the package manager version
-psycopg2>=2.6.1
-requests>=2.7.0
-gunicorn>=19.3.0
+psycopg2==2.6.1
+requests==2.7.0
+gunicorn==19.3.0
 cryptography>=1.0
-Flask-Cors>=2.1.0
-Flask-BasicAuth>=0.2.0
-marshmallow>=2.0.0.b4
-marshmallow-sqlalchemy>=0.4.0
+Flask==0.10.1
+Flask-SQLAlchemy==1.0
+Flask-Cors==2.1.0
+Flask-BasicAuth==0.2.0
+marshmallow==2.0.0.b4
+marshmallow-sqlalchemy==0.4.0
 smore==0.2.0
 cfenv==0.5.2
 


### PR DESCRIPTION
This pins all dependencies in `requirements.txt` to a specific version number. This will make deployments and builds more deterministic and ensure that builds don't randomly break because new versions of dependencies with breaking changes have been released. It also ensures that we don't receive tons of `DeprecationWarning` spam.

For the most part, it just replaces all `>=`'s with `==`. Exceptions noted below via GitHub comments.

The flip side of this change, of course, is that it's on our shoulders to make sure we're using the most recently bug-fixed versions of our dependencies, and that they're not spamming `DeprecationWarning`s on us.
