### PR TITLE
Cloud Foundry forward-compatibility

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn main:app --bind 0.0.0.0:$VCAP_APP_PORT --config hooks.py
+web: gunicorn main:app --bind 0.0.0.0:$PORT --config hooks.py


### PR DESCRIPTION
Per [Cloud Foundry documentation](https://docs.cloudfoundry.org/running/apps-enable-diego.html#app-code) use of `$VCAP_APP_HOST` and `$VCAP_APP_PASSWORD` are incompatible with newer (Diego-based) Cloud Foundry deployments. This change makes this repository forward compatible with the new cloud.gov environment deployment in AWS GovCloud.
