### PR TITLE
Fix error in chunk table loader

### DIFF
--- a/test_load_table.py
+++ b/test_load_table.py
@@ -74,18 +74,32 @@ class TestLoadTable():
         Tom, 1980-02-26, 0
         Dick, 1982-03-14, 3
         Harry, 1972-11-24, 2
+        Chris, 1991-08-03, 0
+        Jill, 1990-04-15, 1
+        Lorenzo, 2003-01-01, 0
+        Alyssa, 2005-02-02, 1
+        Andrew, 2008-03-03, 1
+        Javi, 2008-04-04, 2
         """
 
-        self.load_table(tmpdir, CSV, 'people', chunksize=1)
+        self.load_table(tmpdir, CSV, 'people', chunksize=4)
 
         people = self.meta.tables['people']
 
         connection = self.engine.connect()
         results = connection.execute(
             select([people]).order_by(people.c.index)).fetchall()
+
         assert (0, 'Tom', '1980-02-26', '0') == results[0]
         assert (1, 'Dick', '1982-03-14', '3') == results[1]
         assert (2, 'Harry', '1972-11-24', '2') == results[2]
+        assert (3, 'Chris', '1991-08-03', '0') == results[3]
+        assert (4, 'Jill', '1990-04-15', '1') == results[4]
+        assert (5, 'Lorenzo', '2003-01-01', '0') == results[5]
+        assert (6, 'Alyssa', '2005-02-02', '1') == results[6]
+        assert (7, 'Andrew', '2008-03-03', '1') == results[7]
+        assert (8, 'Javi', '2008-04-04', '2') == results[8]
+
 
     def test_empty_csv(self, tmpdir):
         file_name = 'empty.csv'

--- a/utils.py
+++ b/utils.py
@@ -95,13 +95,13 @@ def load_table(filename,
                          dtype=dtypes,
                          skipinitialspace=True)
     for idx, chunk in enumerate(chunks):
-        chunk.index += chunksize * idx
         to_sql(tablename,
                engine,
                chunk,
                chunksize=chunksize,
                keys='index',
                if_exists='append', )
+
     _index_table(tablename, metadata, engine, config.CASE_INSENSITIVE)
 
 


### PR DESCRIPTION
Currently in `master`, there is a bug that occurs when you want to read a csv in in chunks rather than loading everything in into memory all at once.  There is an erroneous line of code that renumbers the row index based on the `chunksize`, but pandas already keeps track of row indexes correctly.

I also increased the number of test rows in the relevant `pytest`.  If the function is meant to read large csvs in chunks, I felt that it would make sense to use a little more data and use a `chunksize` greater than 1.

Closes #98.

(also thanks @afeld for helping me out with understanding some of the `sqlalchemy` and setup shenanigans at the Hacker Hours event earlier this evening)